### PR TITLE
Support token authentication

### DIFF
--- a/src/main/scala/consul/Consul.scala
+++ b/src/main/scala/consul/Consul.scala
@@ -5,7 +5,7 @@ import java.net.Inet4Address
 import consul.v1.acl.AclRequests
 import consul.v1.agent.AgentRequests
 import consul.v1.catalog.CatalogRequests
-import consul.v1.common.Types
+import consul.v1.common.{ConsulRequestBasics, Types}
 import consul.v1.event.EventRequests
 import consul.v1.health.HealthRequests
 import consul.v1.kv.KvRequests
@@ -26,9 +26,11 @@ trait ConsulApiV1{
 
 }
 
-class Consul(address: Inet4Address, port: Int = 8500)(implicit executionContext: ExecutionContext){
+class Consul(address: Inet4Address, port: Int = 8500, token: Option[String] = None)
+            (implicit executionContext: ExecutionContext){
 
   lazy val v1: ConsulApiV1 with Types = new ConsulApiV1 with Types{
+    private implicit def requestBasics = new ConsulRequestBasics(token)
     private lazy val basePath = s"http://${address.getHostAddress}:$port/v1"
     lazy val health:  HealthRequests  = HealthRequests( basePath)
     lazy val agent:   AgentRequests   = AgentRequests(  basePath)

--- a/src/main/scala/consul/v1/acl/AclRequests.scala
+++ b/src/main/scala/consul/v1/acl/AclRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.acl
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import play.api.http.Status
 import play.api.libs.json.{JsNull, Json}
 
@@ -23,7 +23,9 @@ trait AclRequests {
 
 object AclRequests{
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): AclRequests = new AclRequests{
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): AclRequests = new AclRequests{
+
+    import rb._
 
     def create(acl:AclCreate):Future[AclIdResponse] = erased(
       jsonRequestMaker(createPath,_.put(Json.toJson(acl)))(_.validate[AclIdResponse])

--- a/src/main/scala/consul/v1/acl/AclRequests.scala
+++ b/src/main/scala/consul/v1/acl/AclRequests.scala
@@ -25,10 +25,8 @@ object AclRequests{
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): AclRequests = new AclRequests{
 
-    import rb._
-
-    def create(acl:AclCreate):Future[AclIdResponse] = erased(
-      jsonRequestMaker(createPath,_.put(Json.toJson(acl)))(_.validate[AclIdResponse])
+    def create(acl:AclCreate):Future[AclIdResponse] = rb.erased(
+      rb.jsonRequestMaker(createPath,_.put(Json.toJson(acl)))(_.validate[AclIdResponse])
     )
 
     def create(Name:Option[String],Type:Option[String],Rules:Option[String]):Future[AclIdResponse] = create(
@@ -36,24 +34,24 @@ object AclRequests{
     )
 
     def update(acl: AclUpdate): Future[Boolean] =
-      responseStatusRequestMaker(updatePath,_.put(Json.toJson(acl)))(_ == Status.OK)
+      rb.responseStatusRequestMaker(updatePath,_.put(Json.toJson(acl)))(_ == Status.OK)
 
     def update(ID:AclId,Name:Option[String],Type:Option[String],Rules:Option[String]): Future[Boolean] =
       update(AclUpdate(ID,Name,Type,Rules))
 
     def destroy(id:AclId):Future[Boolean] =
-      responseStatusRequestMaker(fullPathFor(s"destroy/$id"),_.put(JsNull))(_ == Status.OK)
+      rb.responseStatusRequestMaker(fullPathFor(s"destroy/$id"),_.put(JsNull))(_ == Status.OK)
 
-    def list():Future[Seq[AclInfo]] = erased(
-      jsonRequestMaker(listPath,_.get())(_.validate[Seq[AclInfo]])
+    def list():Future[Seq[AclInfo]] = rb.erased(
+      rb.jsonRequestMaker(listPath,_.get())(_.validate[Seq[AclInfo]])
     )
 
-    def info(id:AclId): Future[Option[AclInfo]] = erased(
-      jsonRequestMaker(fullPathFor(s"info/$id"),_.get())(_.validateOpt[AclInfo])
+    def info(id:AclId): Future[Option[AclInfo]] = rb.erased(
+      rb.jsonRequestMaker(fullPathFor(s"info/$id"),_.get())(_.validateOpt[AclInfo])
     )
 
-    def clone(id:AclId): Future[AclIdResponse] = erased(
-      jsonRequestMaker(fullPathFor(s"clone/$id"),_.put(JsNull))(_.validate[AclIdResponse])
+    def clone(id:AclId): Future[AclIdResponse] = rb.erased(
+      rb.jsonRequestMaker(fullPathFor(s"clone/$id"),_.put(JsNull))(_.validate[AclIdResponse])
     )
 
     private lazy val createPath = fullPathFor("create")

--- a/src/main/scala/consul/v1/agent/AgentRequests.scala
+++ b/src/main/scala/consul/v1/agent/AgentRequests.scala
@@ -3,8 +3,7 @@ package consul.v1.agent
 import consul.v1.agent.check.CheckRequests
 import consul.v1.agent.service.ServiceRequests
 
-import consul.v1.common.ConsulRequestBasics._
-import consul.v1.common.{Service, Types}
+import consul.v1.common.{ConsulRequestBasics, Service, Types}
 import consul.v1.common.Types._
 import consul.v1.health.Check
 import play.api.http.Status
@@ -30,7 +29,9 @@ trait AgentRequests {
 
 object AgentRequests {
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): AgentRequests = new AgentRequests {
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): AgentRequests = new AgentRequests {
+
+    import rb._
 
     def self() = erased(
       jsonRequestMaker(fullPathFor("self"), _.get())(_.validate[JsObject])

--- a/src/main/scala/consul/v1/agent/AgentRequests.scala
+++ b/src/main/scala/consul/v1/agent/AgentRequests.scala
@@ -31,34 +31,32 @@ object AgentRequests {
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): AgentRequests = new AgentRequests {
 
-    import rb._
-
-    def self() = erased(
-      jsonRequestMaker(fullPathFor("self"), _.get())(_.validate[JsObject])
+    def self() = rb.erased(
+      rb.jsonRequestMaker(fullPathFor("self"), _.get())(_.validate[JsObject])
     )
 
-    def join(address: String,wan:Boolean): Future[Boolean] = responseStatusRequestMaker(
+    def join(address: String,wan:Boolean): Future[Boolean] = rb.responseStatusRequestMaker(
       fullPathFor(s"join/$address"),
       (r:WSRequest) => (if(wan) r.withQueryString(("wan","1")) else r).get()
     )( _ == Status.OK )
 
-    def `force-leave`(node: Types.NodeId): Future[Boolean] = responseStatusRequestMaker(
+    def `force-leave`(node: Types.NodeId): Future[Boolean] = rb.responseStatusRequestMaker(
       fullPathFor(s"force-leave/$node"),_.get()
     )( _ == Status.OK )
 
     def maintenance(enable:Boolean,reason:Option[String]): Future[Boolean] = {
       lazy val params = Seq(("enable",enable.toString)) ++ reason.map("reason"->_)
-      responseStatusRequestMaker( maintenancePath, _.withQueryString(params:_*).put(JsNull) )(_ == Status.OK)
+      rb.responseStatusRequestMaker( maintenancePath, _.withQueryString(params:_*).put(JsNull) )(_ == Status.OK)
     }
 
-    def checks(): Future[Map[CheckId, Check]] = erased(
-      jsonRequestMaker(checksPath, _.get() )(
+    def checks(): Future[Map[CheckId, Check]] = rb.erased(
+      rb.jsonRequestMaker(checksPath, _.get() )(
         _.validate[Map[String,Check]].map(_.map{ case (key,value) => CheckId(key)->value })
       )
     )
 
-    def services(): Future[Map[ServiceId,Service]] = erased(
-      jsonRequestMaker(servicesPath, _.get() )(
+    def services(): Future[Map[ServiceId,Service]] = rb.erased(
+      rb.jsonRequestMaker(servicesPath, _.get() )(
         _.validate[Map[String,Service]].map(_.map{ case (key,value) => ServiceId(key)->value })
       )
     )

--- a/src/main/scala/consul/v1/agent/check/CheckRequests.scala
+++ b/src/main/scala/consul/v1/agent/check/CheckRequests.scala
@@ -48,13 +48,11 @@ object CheckRequests{
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): CheckRequests = new CheckRequests {
 
-    import rb._
-
-    def register(check: Check): Future[Boolean] = responseStatusRequestMaker(
+    def register(check: Check): Future[Boolean] = rb.responseStatusRequestMaker(
       registerPath,_.put(Json.toJson(check))
     )(_ == Status.OK)
 
-    def deregister(checkId: CheckId): Future[Boolean] = responseStatusRequestMaker(
+    def deregister(checkId: CheckId): Future[Boolean] = rb.responseStatusRequestMaker(
       fullPathFor(s"deregister/$checkId"),_.get()
     )(_ == Status.OK)
 
@@ -65,7 +63,7 @@ object CheckRequests{
     def fail(checkId: CheckId,note:Option[String]): Future[Boolean] = functionForStatus("fail")(checkId,note)
 
     private def functionForStatus(status:String) = (checkId: CheckId,note:Option[String]) =>
-      responseStatusRequestMaker(
+      rb.responseStatusRequestMaker(
         fullPathFor(s"$status/$checkId"),
         (r:WSRequest) => note.map{ case note => r.withQueryString("note"->note) }.getOrElse( r ).get()
       )(_ == Status.OK)

--- a/src/main/scala/consul/v1/agent/check/CheckRequests.scala
+++ b/src/main/scala/consul/v1/agent/check/CheckRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.agent.check
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types.CheckId
 import play.api.http.Status
 import play.api.libs.json.{Writes, Json}
@@ -46,7 +46,9 @@ trait CheckRequests extends CheckCreators{
 
 object CheckRequests{
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): CheckRequests = new CheckRequests {
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): CheckRequests = new CheckRequests {
+
+    import rb._
 
     def register(check: Check): Future[Boolean] = responseStatusRequestMaker(
       registerPath,_.put(Json.toJson(check))

--- a/src/main/scala/consul/v1/agent/service/ServiceRequests.scala
+++ b/src/main/scala/consul/v1/agent/service/ServiceRequests.scala
@@ -30,21 +30,19 @@ object ServiceRequests {
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): ServiceRequests = new ServiceRequests{
 
-    import rb._
-
     def maintenance(serviceID: ServiceId,enable:Boolean,reason:Option[String]): Future[Boolean] = {
       lazy val params = Seq(("enable",enable.toString)) ++ reason.map("reason"->_)
-      responseStatusRequestMaker(
+      rb.responseStatusRequestMaker(
         fullPathFor(s"maintenance/$serviceID"),
         _.withQueryString(params:_*).put(JsNull)
       )(_ == Status.OK)
     }
 
     def register(localService: LocalService): Future[Boolean] =
-      responseStatusRequestMaker(fullPathFor("register"), _.put(Json.toJson(localService)))(_ == Status.OK)
+      rb.responseStatusRequestMaker(fullPathFor("register"), _.put(Json.toJson(localService)))(_ == Status.OK)
 
     def deregister(serviceID: ServiceId): Future[Boolean] =
-      responseStatusRequestMaker(fullPathFor(s"deregister/$serviceID"), _.get())(_ == Status.OK)
+      rb.responseStatusRequestMaker(fullPathFor(s"deregister/$serviceID"), _.get())(_ == Status.OK)
 
     private def fullPathFor(path: String) = s"$basePath/service/$path"
 

--- a/src/main/scala/consul/v1/agent/service/ServiceRequests.scala
+++ b/src/main/scala/consul/v1/agent/service/ServiceRequests.scala
@@ -1,7 +1,7 @@
 package consul.v1.agent.service
 
 import consul.v1.agent.service.LocalService.{apply => applied}
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types._
 import play.api.http.Status
 import play.api.libs.json.{JsNull, Json, Writes}
@@ -28,7 +28,9 @@ object ServiceRequests {
 
   private implicit lazy val CheckWrites: Writes[Check] = Json.writes[Check]
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): ServiceRequests = new ServiceRequests{
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): ServiceRequests = new ServiceRequests{
+
+    import rb._
 
     def maintenance(serviceID: ServiceId,enable:Boolean,reason:Option[String]): Future[Boolean] = {
       lazy val params = Seq(("enable",enable.toString)) ++ reason.map("reason"->_)

--- a/src/main/scala/consul/v1/catalog/CatalogRequests.scala
+++ b/src/main/scala/consul/v1/catalog/CatalogRequests.scala
@@ -1,9 +1,8 @@
 package consul.v1.catalog
 
 import consul.v1.common.CheckStatus._
-import consul.v1.common.ConsulRequestBasics._
 import consul.v1.common.Types._
-import consul.v1.common.{Node, Types}
+import consul.v1.common.{ConsulRequestBasics, Node, Types}
 import play.api.http.Status
 import play.api.libs.json._
 import play.api.libs.ws.WSRequest
@@ -52,7 +51,9 @@ object CatalogRequests {
     Json.writes[Registerable]
   }
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): CatalogRequests = new CatalogRequests {
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): CatalogRequests = new CatalogRequests {
+
+    import rb._
 
     def register(registerable: Registerable): Future[Boolean] = responseStatusRequestMaker(
       registerPath,

--- a/src/main/scala/consul/v1/catalog/CatalogRequests.scala
+++ b/src/main/scala/consul/v1/catalog/CatalogRequests.scala
@@ -53,38 +53,36 @@ object CatalogRequests {
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): CatalogRequests = new CatalogRequests {
 
-    import rb._
-
-    def register(registerable: Registerable): Future[Boolean] = responseStatusRequestMaker(
+    def register(registerable: Registerable): Future[Boolean] = rb.responseStatusRequestMaker(
       registerPath,
       _.put( Json.toJson(registerable) )
     )(_ == Status.OK)
 
-    def deregister(deregisterable:Deregisterable):Future[Boolean] = responseStatusRequestMaker(
+    def deregister(deregisterable:Deregisterable):Future[Boolean] = rb.responseStatusRequestMaker(
       deregisterPath,
       _.put(Json.toJson(deregisterable))
     )(_ == Status.OK)
 
-    def nodes(dc:Option[DatacenterId]) = erased(
-      jsonDcRequestMaker(fullPathFor("nodes"),dc, _.get())(_.validate[Seq[Node]])
+    def nodes(dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor("nodes"),dc, _.get())(_.validate[Seq[Node]])
     )
 
-    def node(nodeID: NodeId, dc:Option[DatacenterId]) = erased(
-      jsonDcRequestMaker(fullPathFor(s"node/$nodeID"),dc, _.get())(_.validate[NodeProvidedServices])
+    def node(nodeID: NodeId, dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor(s"node/$nodeID"),dc, _.get())(_.validate[NodeProvidedServices])
     )
 
-    def service(service: ServiceType, tag:Option[ServiceTag], dc:Option[DatacenterId]) = erased(
-      jsonDcRequestMaker(fullPathFor(s"service/$service"),dc,
+    def service(service: ServiceType, tag:Option[ServiceTag], dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor(s"service/$service"),dc,
         (r:WSRequest) => tag.map{ case tag => r.withQueryString("tag"->tag) }.getOrElse(r).get()
       )(_.validate[Seq[NodeProvidingService]])
     )
 
-    def datacenters(): Future[Seq[DatacenterId]] = erased(
-      jsonRequestMaker(datacenterPath, _.get() )(_.validate[Seq[DatacenterId]])
+    def datacenters(): Future[Seq[DatacenterId]] = rb.erased(
+      rb.jsonRequestMaker(datacenterPath, _.get() )(_.validate[Seq[DatacenterId]])
     )
 
-    def services(dc:Option[DatacenterId]=Option.empty): Future[Map[Types.ServiceType, Set[String]]] = erased(
-      jsonDcRequestMaker(servicesPath, dc, _.get())(
+    def services(dc:Option[DatacenterId]=Option.empty): Future[Map[Types.ServiceType, Set[String]]] = rb.erased(
+      rb.jsonDcRequestMaker(servicesPath, dc, _.get())(
         _.validate[Map[String,Set[String]]].map(_.map{ case (key,value) => ServiceType(key)->value })
       )
     )

--- a/src/main/scala/consul/v1/event/EventRequests.scala
+++ b/src/main/scala/consul/v1/event/EventRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.event
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types._
 import play.api.http.{ContentTypeOf, Writeable}
 import play.api.libs.json.Json
@@ -20,7 +20,9 @@ object EventRequests{
 
   private implicit lazy val eventReads = Json.reads[Event]
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext):EventRequests = new EventRequests {
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics):EventRequests = new EventRequests {
+
+    import rb._
 
     def fire[T](name:String, payload:T,node:Option[NodeId],service:Option[ServiceId],tag:Option[ServiceTag],dc:Option[DatacenterId])(
                 implicit wrt: Writeable[T], ct: ContentTypeOf[T]):Future[Event] = {

--- a/src/main/scala/consul/v1/event/EventRequests.scala
+++ b/src/main/scala/consul/v1/event/EventRequests.scala
@@ -22,21 +22,19 @@ object EventRequests{
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics):EventRequests = new EventRequests {
 
-    import rb._
-
     def fire[T](name:String, payload:T,node:Option[NodeId],service:Option[ServiceId],tag:Option[ServiceTag],dc:Option[DatacenterId])(
                 implicit wrt: Writeable[T], ct: ContentTypeOf[T]):Future[Event] = {
 
       val params = node.map("node"->_.toString).toList ++ service.map("service"->_.toString) ++ tag.map("tag"->_.toString)
-      erased(
-        jsonDcRequestMaker(fullPathFor(s"fire/$name"),dc,
+      rb.erased(
+        rb.jsonDcRequestMaker(fullPathFor(s"fire/$name"),dc,
           _.withQueryString(params:_*).put(payload)
         )(_.validate[Event])
       )
     }
 
-    def list(name: Option[String]): Future[List[Event]] = erased(
-      jsonRequestMaker(listPath,
+    def list(name: Option[String]): Future[List[Event]] = rb.erased(
+      rb.jsonRequestMaker(listPath,
         (r:WSRequest) => name.map{ case name => r.withQueryString("name"->name) }.getOrElse(r).get()
       )(_.validate[List[Event]])
     )

--- a/src/main/scala/consul/v1/health/HealthRequests.scala
+++ b/src/main/scala/consul/v1/health/HealthRequests.scala
@@ -1,7 +1,7 @@
 package consul.v1.health
 
 import consul.v1.common.CheckStatus.CheckStatus
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types.{NodeId, ServiceType,ServiceTag,DatacenterId}
 import play.api.libs.json.{Json, Reads}
 
@@ -18,7 +18,8 @@ object HealthRequests {
 
   implicit private val NodesHealthServiceReads: Reads[NodesHealthService] = Json.reads[NodesHealthService]
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): HealthRequests = new HealthRequests {
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): HealthRequests = new HealthRequests {
+    import rb._
 
     def service(service: ServiceType, tag:Option[ServiceTag], passing:Boolean=false,dc:Option[DatacenterId]): Future[Seq[NodesHealthService]] = erased{
       lazy val params = (if(passing) List(("passing","")) else List.empty ) ++ tag.map{ case tag => (("tag",tag.toString)) }

--- a/src/main/scala/consul/v1/health/HealthRequests.scala
+++ b/src/main/scala/consul/v1/health/HealthRequests.scala
@@ -19,7 +19,7 @@ object HealthRequests {
   implicit private val NodesHealthServiceReads: Reads[NodesHealthService] = Json.reads[NodesHealthService]
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): HealthRequests = new HealthRequests {
-    def service(service: ServiceType, tag:Option[ServiceTag], passing:Boolean=false,dc:Option[DatacenterId]): Future[Seq[NodesHealthService]] = erased{
+    def service(service: ServiceType, tag:Option[ServiceTag], passing:Boolean=false,dc:Option[DatacenterId]): Future[Seq[NodesHealthService]] = rb.erased{
       lazy val params = (if(passing) List(("passing","")) else List.empty ) ++ tag.map{ case tag => (("tag",tag.toString)) }
 
       rb.jsonDcRequestMaker(

--- a/src/main/scala/consul/v1/health/HealthRequests.scala
+++ b/src/main/scala/consul/v1/health/HealthRequests.scala
@@ -19,27 +19,25 @@ object HealthRequests {
   implicit private val NodesHealthServiceReads: Reads[NodesHealthService] = Json.reads[NodesHealthService]
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): HealthRequests = new HealthRequests {
-    import rb._
-
     def service(service: ServiceType, tag:Option[ServiceTag], passing:Boolean=false,dc:Option[DatacenterId]): Future[Seq[NodesHealthService]] = erased{
       lazy val params = (if(passing) List(("passing","")) else List.empty ) ++ tag.map{ case tag => (("tag",tag.toString)) }
 
-      jsonDcRequestMaker(
+      rb.jsonDcRequestMaker(
         fullPathFor(s"service/$service"),dc,
         _.withQueryString(params:_*).get()
       )(_.validate[Seq[NodesHealthService]])
     }
 
-    def node(nodeID: NodeId,dc:Option[DatacenterId]) = erased(
-      jsonDcRequestMaker(fullPathFor(s"node/$nodeID"),dc, _.get())(_.validate[Seq[Check]])
+    def node(nodeID: NodeId,dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor(s"node/$nodeID"),dc, _.get())(_.validate[Seq[Check]])
     )
 
-    def checks(serviceID:ServiceType,dc:Option[DatacenterId]) = erased(
-      jsonDcRequestMaker(fullPathFor(s"checks/$serviceID"),dc, _.get())(_.validate[Seq[Check]])
+    def checks(serviceID:ServiceType,dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor(s"checks/$serviceID"),dc, _.get())(_.validate[Seq[Check]])
     )
 
-    def state(state:CheckStatus,dc:Option[DatacenterId]): Future[Seq[Check]] = erased(
-      jsonDcRequestMaker(fullPathFor(s"state/$state"),dc,_.get())(_.validate[Seq[Check]])
+    def state(state:CheckStatus,dc:Option[DatacenterId]): Future[Seq[Check]] = rb.erased(
+      rb.jsonDcRequestMaker(fullPathFor(s"state/$state"),dc,_.get())(_.validate[Seq[Check]])
     )
 
     private def fullPathFor(path: String) = s"$basePath/health/$path"

--- a/src/main/scala/consul/v1/kv/KvRequests.scala
+++ b/src/main/scala/consul/v1/kv/KvRequests.scala
@@ -18,10 +18,8 @@ object KvRequests {
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): KvRequests = new KvRequests{
 
-    import rb._
-
-    def get(key: String,recurse:Boolean,dc:Option[DatacenterId]) = erased(
-      jsonRequestMaker(
+    def get(key: String,recurse:Boolean,dc:Option[DatacenterId]) = rb.erased(
+      rb.jsonRequestMaker(
         fullPathFor(key),
         httpFunc = recurseDcRequestHolder(recurse,dc).andThen( _.get() )
       )(_.validateOpt[List[KvValue]].map(_.getOrElse(List.empty)))
@@ -31,15 +29,14 @@ object KvRequests {
       //this could be wrong - could be a simple string that is returned and we have to check if "true" or "false"
       val params = flags.map("flags"->_.toString).toList ++ acquire.map("acquire"->_.toString) ++ release.map("release"->_)
 
-      jsonDcRequestMaker(
+      rb.jsonDcRequestMaker(
         fullPathFor(key),dc,
         httpFunc = _.withQueryString(params:_*).put(value)
       )(_.validate[Boolean].getOrElse(false))
     }
 
     def delete(key: String, recurse: Boolean, dc:Option[DatacenterId]): Future[Boolean] = {
-
-      responseStatusRequestMaker(fullPathFor(key),
+      rb.responseStatusRequestMaker(fullPathFor(key),
        httpFunc = recurseDcRequestHolder(recurse,dc).andThen( _.delete() )
       )(_ => true)
     }

--- a/src/main/scala/consul/v1/kv/KvRequests.scala
+++ b/src/main/scala/consul/v1/kv/KvRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.kv
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types._
 import play.api.http.{ContentTypeOf, Writeable}
 import play.api.libs.ws.WSRequest
@@ -16,7 +16,9 @@ trait KvRequests {
 
 object KvRequests {
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): KvRequests = new KvRequests{
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): KvRequests = new KvRequests{
+
+    import rb._
 
     def get(key: String,recurse:Boolean,dc:Option[DatacenterId]) = erased(
       jsonRequestMaker(

--- a/src/main/scala/consul/v1/session/SessionRequests.scala
+++ b/src/main/scala/consul/v1/session/SessionRequests.scala
@@ -32,39 +32,37 @@ object SessionRequests{
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): SessionRequests = new SessionRequests{
 
-    import rb._
-
-    def create(sessionDef: SessionDef,dc:Option[DatacenterId]): Future[SessionIDHolder] = erased(
-      jsonDcRequestMaker(
+    def create(sessionDef: SessionDef,dc:Option[DatacenterId]): Future[SessionIDHolder] = rb.erased(
+      rb.jsonDcRequestMaker(
         createPath,dc,
         _.put(Json.toJson(sessionDef))
       )(_.validate[SessionIDHolder])
     )
 
-    def node(node:NodeId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = erased(
-      jsonDcRequestMaker(
+    def node(node:NodeId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = rb.erased(
+      rb.jsonDcRequestMaker(
         fullPathFor(s"node/$node"),dc,_.get
       )( _.validate[Seq[SessionInfo]] )
     )
 
-    def destroy(id:SessionId,dc:Option[DatacenterId]):Future[Boolean] = responseStatusDcRequestMaker(
+    def destroy(id:SessionId,dc:Option[DatacenterId]):Future[Boolean] = rb.responseStatusDcRequestMaker(
       fullPathFor(s"destroy/$id"),dc,_.put("")
     )(_ == Status.OK)
 
-    def list(dc:Option[DatacenterId]):Future[Seq[SessionInfo]] = erased(
-      jsonDcRequestMaker(
+    def list(dc:Option[DatacenterId]):Future[Seq[SessionInfo]] = rb.erased(
+      rb.jsonDcRequestMaker(
         listPath,dc,_.get
       )(_.validate[Seq[SessionInfo]])
     )
 
-    def renew(id:SessionId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = erased(
-      jsonDcRequestMaker(
+    def renew(id:SessionId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = rb.erased(
+      rb.jsonDcRequestMaker(
         fullPathFor(s"renew/$id"),dc,_.put("")
       )(_.validate[Seq[SessionInfo]])
     )
 
-    def info(id:SessionId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = erased(
-      jsonDcRequestMaker(
+    def info(id:SessionId,dc:Option[DatacenterId]=Option.empty):Future[Seq[SessionInfo]] = rb.erased(
+      rb.jsonDcRequestMaker(
         fullPathFor(s"info/$id"),dc,_.get
       )( _.validate[Seq[SessionInfo]] )
     )

--- a/src/main/scala/consul/v1/session/SessionRequests.scala
+++ b/src/main/scala/consul/v1/session/SessionRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.session
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import consul.v1.common.Types._
 import play.api.http.Status
 import play.api.libs.json.Json
@@ -30,7 +30,9 @@ object SessionRequests{
   private lazy implicit val SessionInfoReads     = Json.reads[SessionInfo]
   private lazy implicit val SessionDefWrites     = Json.writes[SessionDef]
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): SessionRequests = new SessionRequests{
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): SessionRequests = new SessionRequests{
+
+    import rb._
 
     def create(sessionDef: SessionDef,dc:Option[DatacenterId]): Future[SessionIDHolder] = erased(
       jsonDcRequestMaker(

--- a/src/main/scala/consul/v1/status/StatusRequests.scala
+++ b/src/main/scala/consul/v1/status/StatusRequests.scala
@@ -11,14 +11,12 @@ object StatusRequests{
 
   def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): StatusRequests = new StatusRequests{
 
-    import rb._
-
-    def leader(): Future[Option[String]] = erased(
-      jsonRequestMaker(fullPathFor("leader"),_.get())(_.validateOpt[String])
+    def leader(): Future[Option[String]] = rb.erased(
+      rb.jsonRequestMaker(fullPathFor("leader"),_.get())(_.validateOpt[String])
     )
 
-    def peers(): Future[Seq[String]] = erased(
-      jsonRequestMaker(fullPathFor("peers"),_.get())(_.validate[Seq[String]])
+    def peers(): Future[Seq[String]] = rb.erased(
+      rb.jsonRequestMaker(fullPathFor("peers"),_.get())(_.validate[Seq[String]])
     )
 
     private def fullPathFor(path: String) = s"$basePath/status/$path"

--- a/src/main/scala/consul/v1/status/StatusRequests.scala
+++ b/src/main/scala/consul/v1/status/StatusRequests.scala
@@ -1,6 +1,6 @@
 package consul.v1.status
 
-import consul.v1.common.ConsulRequestBasics._
+import consul.v1.common.ConsulRequestBasics
 import scala.concurrent.{ExecutionContext, Future}
 
 trait StatusRequests {
@@ -9,7 +9,9 @@ trait StatusRequests {
 }
 object StatusRequests{
 
-  def apply(basePath: String)(implicit executionContext: ExecutionContext): StatusRequests = new StatusRequests{
+  def apply(basePath: String)(implicit executionContext: ExecutionContext, rb: ConsulRequestBasics): StatusRequests = new StatusRequests{
+
+    import rb._
 
     def leader(): Future[Option[String]] = erased(
       jsonRequestMaker(fullPathFor("leader"),_.get())(_.validateOpt[String])


### PR DESCRIPTION
We are using token authentication in our consul setup. This pull request adds ability to sign all requests with token, if passed. I changed ConsulRequestBasics signature, moving from object to class, because I want to move building full uri from *Requests classes to ConsulRequestBasics in next PR.
