### PR TITLE
Add address to LocalService definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import consul.Consul
 
 instanciate a consul supplying an ip and an optional port indicating a working consul agent:
 ```scala
-val myConsul = new consul.Consul(CONSUL_IP,Option(CONSUL_PORT))
+val myConsul = new consul.Consul(CONSUL_IP,Option(CONSUL_PORT),Option(CONSUL_ACL_TOKEN)
 import myConsul.v1._
 ```
 
@@ -37,9 +37,10 @@ catalog.nodes().map{ case nodes =>
 
 Example - register a service with an http-check on the local node:
 ```scala
+val myAddress = "127.0.0.1"
 val myServicePort = 5000
 val myServiceCheck = agent.service.httpCheck(s"http://localhost:$myServicePort/health","15s")
-val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck))
+val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck),Some(myAddress))
 agent.service.register(myService)
 ```
 the check ID of the registered service-check is available via: 

--- a/src/main/scala/consul/v1/agent/service/LocalService.scala
+++ b/src/main/scala/consul/v1/agent/service/LocalService.scala
@@ -4,7 +4,8 @@ import consul.v1.common.Types.{CheckId, ServiceId, ServiceTag, ServiceType}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class LocalService(ID: ServiceId, Name: ServiceType, Tags: Set[ServiceTag] = Set.empty, Port: Option[Int], Check: Option[Check]){
+case class LocalService(ID: ServiceId, Name: ServiceType, Tags: Set[ServiceTag] = Set.empty, Port: Option[Int], Check: Option[Check],
+                        Address: Option[String] = None){
   lazy val checkId:CheckId = CheckId(s"service:$ID")
 }
 
@@ -14,7 +15,8 @@ object LocalService {
       (__ \ "Name" ).write[ServiceType] and
       (__ \ "Tags" ).write[Set[ServiceTag]] and
       (__ \ "Port" ).write[Option[Int]] and
-      (__ \ "Check").write[Option[Check]]
+      (__ \ "Check").write[Option[Check]] and
+      (__ \ "Address").write[Option[String]]
     )(  unlift(LocalService.unapply) )
 
   //no id is provided -> id becomes name


### PR DESCRIPTION
Documentation (https://www.consul.io/docs/agent/http/agent.html#agent_service_register) says, that `/agent/service/register` call also supports `Address` field.
We need this, because in our setup our services and consul agent are on the different IPs.
 Without this field consul registers service on the same IP address, as consul itself.
