### PR TITLE
Support use of stand-alone Play WS client

### DIFF
--- a/src/main/scala/consul/Consul.scala
+++ b/src/main/scala/consul/Consul.scala
@@ -2,6 +2,7 @@ package consul
 
 import java.net.InetAddress
 
+import com.ning.http.client.AsyncHttpClientConfig
 import consul.v1.acl.AclRequests
 import consul.v1.agent.AgentRequests
 import consul.v1.catalog.CatalogRequests
@@ -11,6 +12,9 @@ import consul.v1.health.HealthRequests
 import consul.v1.kv.KvRequests
 import consul.v1.session.SessionRequests
 import consul.v1.status.StatusRequests
+import play.api.Application
+import play.api.libs.ws.{WS, WSClient}
+import play.api.libs.ws.ning.NingWSClient
 
 import scala.concurrent.ExecutionContext
 
@@ -26,11 +30,11 @@ trait ConsulApiV1{
 
 }
 
-class Consul(address: InetAddress, port: Int = 8500, token: Option[String] = None)
+class Consul(address: InetAddress, port: Int = 8500, token: Option[String] = None, client: WSClient)
             (implicit executionContext: ExecutionContext){
 
   lazy val v1: ConsulApiV1 with Types = new ConsulApiV1 with Types{
-    private implicit def requestBasics = new ConsulRequestBasics(token)
+    private implicit def requestBasics = new ConsulRequestBasics(token, client)
     private lazy val basePath = s"http://${address.getHostAddress}:$port/v1"
     lazy val health:  HealthRequests  = HealthRequests( basePath)
     lazy val agent:   AgentRequests   = AgentRequests(  basePath)
@@ -42,4 +46,17 @@ class Consul(address: InetAddress, port: Int = 8500, token: Option[String] = Non
     lazy val event:   EventRequests   = EventRequests(  basePath)
   }
 
+}
+
+object Consul {
+  def inApplication(address: InetAddress, port: Int = 8500, token: Option[String] = None)
+                   (implicit executionContext: ExecutionContext, app: Application): Consul =
+    new Consul(address, port, token, WS.client)
+
+  def standalone(address: InetAddress, port: Int = 8500, token: Option[String] = None)
+                (implicit executionContext: ExecutionContext): Consul = {
+    val builder = new AsyncHttpClientConfig.Builder()
+    val client = new NingWSClient(builder.build())
+    new Consul(address, port, token, client)
+  }
 }


### PR DESCRIPTION
This addresses #14. I'm not set on anything about the API, but wanted something to start discussion.

I've added a `WSClient` argument to the `ConsulRequestBasics` constructor, and have created an auxiliary constructor that uses the default `WS.client` if an application is available, so `ConsulRequestBasics` usage is more or less unchanged (although you may newly need to import `play.api.Play.current` at call sites).

We can't do the same thing for `Consul` because of the default arguments, so I've added a couple of constructor methods to a new companion object. Note that `Consul.standalone` is provided for convenience and does not provide any way to close the client—if that's a deal-breaker you should create your own client that you can manage yourself and use the `Consul` class constructor directly.
