### PR TITLE
Add (type-safe) address to LocalService definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import consul.Consul
 
 instanciate a consul supplying an ip and a port indicating a working consul agent:
 ```scala
-val myConsul = new consul.Consul(CONSUL_IP, CONSUL_PORT)
+val myConsul = new consul.Consul(CONSUL_IP, CONSUL_PORT, Option(CONSUL_ACL_TOKEN))
 import myConsul.v1._
 ```
 
@@ -38,9 +38,10 @@ catalog.nodes().map{ case nodes =>
 
 Example - register a service with an http-check on the local node:
 ```scala
+val myAddress = "127.0.0.1"
 val myServicePort = 5000
 val myServiceCheck = agent.service.httpCheck(s"http://localhost:$myServicePort/health","15s")
-val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck))
+val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck),Some(myAddress))
 agent.service.register(myService)
 ```
 the check ID of the registered service-check is available via: 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example - register a service with an http-check on the local node:
 val myAddress = "127.0.0.1"
 val myServicePort = 5000
 val myServiceCheck = agent.service.httpCheck(s"http://localhost:$myServicePort/health","15s")
-val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck),Some(myAddress))
+val myService = agent.service.LocalService(ServiceId("myServiceId"),ServiceType("myTypeOfService"),Set(ServiceTag("MyTag")),Some(myServicePort),Some(myServiceCheck),Some(Address(myAddress)))
 agent.service.register(myService)
 ```
 the check ID of the registered service-check is available via: 

--- a/src/main/scala/consul/v1/agent/service/LocalService.scala
+++ b/src/main/scala/consul/v1/agent/service/LocalService.scala
@@ -1,11 +1,11 @@
 package consul.v1.agent.service
 
-import consul.v1.common.Types.{CheckId, ServiceId, ServiceTag, ServiceType}
+import consul.v1.common.Types.{Address, CheckId, ServiceId, ServiceTag, ServiceType}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class LocalService(ID: ServiceId, Name: ServiceType, Tags: Set[ServiceTag] = Set.empty, Port: Option[Int], Check: Option[Check],
-                        Address: Option[String] = None){
+                        Address: Option[Address] = None){
   lazy val checkId:CheckId = CheckId(s"service:$ID")
 }
 
@@ -16,7 +16,7 @@ object LocalService {
       (__ \ "Tags" ).write[Set[ServiceTag]] and
       (__ \ "Port" ).write[Option[Int]] and
       (__ \ "Check").write[Option[Check]] and
-      (__ \ "Address").write[Option[String]]
+      (__ \ "Address").write[Option[Address]]
     )(  unlift(LocalService.unapply) )
 
   //no id is provided -> id becomes name

--- a/src/main/scala/consul/v1/agent/service/LocalService.scala
+++ b/src/main/scala/consul/v1/agent/service/LocalService.scala
@@ -4,7 +4,8 @@ import consul.v1.common.Types.{CheckId, ServiceId, ServiceTag, ServiceType}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-case class LocalService(ID: ServiceId, Name: ServiceType, Tags: Set[ServiceTag] = Set.empty, Port: Option[Int], Check: Option[Check]){
+case class LocalService(ID: ServiceId, Name: ServiceType, Tags: Set[ServiceTag] = Set.empty, Port: Option[Int], Check: Option[Check],
+                        Address: Option[String] = None){
   lazy val checkId:CheckId = CheckId(s"service:$ID")
 }
 
@@ -14,7 +15,8 @@ object LocalService {
       (__ \ "Name" ).write[ServiceType] and
       (__ \ "Tags" ).write[Set[ServiceTag]] and
       (__ \ "Port" ).write[Option[Int]] and
-      (__ \ "Check").write[Option[Check]]
+      (__ \ "Check").write[Option[Check]] and
+      (__ \ "Address").write[Option[String]]
     )(  unlift(LocalService.unapply) )
 
   //no id is provided -> id becomes name

--- a/src/main/scala/consul/v1/common/Types.scala
+++ b/src/main/scala/consul/v1/common/Types.scala
@@ -23,6 +23,9 @@ trait Types {
 
   type DatacenterId = WrappedType[String,DatacenterIds]
   def DatacenterId: String => DatacenterId = WrappedType.apply
+
+  type Address = WrappedType[String, Addresses]
+  def Address: String => Address = WrappedType.apply
 }
 
 object Types extends Types{
@@ -33,6 +36,7 @@ object Types extends Types{
   sealed trait ServiceTypes
   sealed trait ServiceTags
   sealed trait DatacenterIds
+  sealed trait Addresses
 
   case class ConsulResponseParseException(error:JsError) extends Throwable
 }


### PR DESCRIPTION
This includes @igorynia's commits in #11, but rebased and with the type-safe `Address` wrapper suggested by @johannegger.
