### PR TITLE
upgraded play-ws and play-json libraries to version 2.5.8 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@
 /project/target/
 /target/
 .idea
+/bin/
+
+.cache-main
+.project
+.classpath
+.settings/
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := """scala-consul"""
 
-version := "1.1.0-SNAPSHOT"
+version := "1.2.0-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
@@ -15,9 +15,13 @@ scalacOptions ++= Seq(
 
 resolvers += "Bintray Typesafe Repo" at "http://dl.bintray.com/typesafe/maven-releases/"
 
+val playVersion = settingKey[String]("The version of play libraries to use")
+
+playVersion := "2.5.8"
+
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.4.3",
-  "com.typesafe.play" %% "play-ws"   % "2.4.3"
+  "com.typesafe.play" %% "play-json" % playVersion.value,
+  "com.typesafe.play" %% "play-ws"   % playVersion.value
 )
 
 organization := "com.codacy"

--- a/src/main/scala/consul/v1/common/ConsulRequestBasics.scala
+++ b/src/main/scala/consul/v1/common/ConsulRequestBasics.scala
@@ -1,16 +1,13 @@
 package consul.v1.common
 
-import com.ning.http.client.AsyncHttpClientConfig
 import consul.v1.common.Types.DatacenterId
 import play.api.libs.json._
-import play.api.libs.ws.{WS, WSClient, WSRequest, WSResponse}
-import play.api.libs.ws.ning.NingWSClient
-import play.api.Application
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 class ConsulRequestBasics(token: Option[String], client: WSClient) {
-  def this(token: Option[String])(implicit app: Application) = this(token, WS.client)
+  // you must provide a WSClient and manage its lifecycle
 
   type HttpFunc = WSRequest => Future[WSResponse]
   type RequestTransformer = WSRequest => WSRequest


### PR DESCRIPTION
Jar version to 1.2.0

NOTE:  the singleton WS.client is deprecated in play 2.5.X
