### PR TITLE
Upgrade Play libraries 2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := """scala-consul"""
 
-version := "1.1.0-SNAPSHOT"
+version := "1.2.0-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq(scalaVersion.value)
 
@@ -16,8 +16,8 @@ scalacOptions ++= Seq(
 resolvers += "Bintray Typesafe Repo" at "http://dl.bintray.com/typesafe/maven-releases/"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.4.3",
-  "com.typesafe.play" %% "play-ws"   % "2.4.3"
+  "com.typesafe.play" %% "play-json" % "2.5.8",
+  "com.typesafe.play" %% "play-ws"   % "2.5.8"
 )
 
 organization := "com.codacy"

--- a/src/main/scala/consul/Consul.scala
+++ b/src/main/scala/consul/Consul.scala
@@ -2,7 +2,8 @@ package consul
 
 import java.net.InetAddress
 
-import com.ning.http.client.AsyncHttpClientConfig
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import consul.v1.acl.AclRequests
 import consul.v1.agent.AgentRequests
 import consul.v1.catalog.CatalogRequests
@@ -12,9 +13,10 @@ import consul.v1.health.HealthRequests
 import consul.v1.kv.KvRequests
 import consul.v1.session.SessionRequests
 import consul.v1.status.StatusRequests
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import play.api.Application
+import play.api.libs.ws.ahc.AhcWSClient
 import play.api.libs.ws.{WS, WSClient}
-import play.api.libs.ws.ning.NingWSClient
 
 import scala.concurrent.ExecutionContext
 
@@ -55,8 +57,10 @@ object Consul {
 
   def standalone(address: InetAddress, port: Int = 8500, token: Option[String] = None)
                 (implicit executionContext: ExecutionContext): Consul = {
-    val builder = new AsyncHttpClientConfig.Builder()
-    val client = new NingWSClient(builder.build())
+    implicit val system = ActorSystem("ahcSystem", defaultExecutionContext = Some(executionContext))
+    implicit val materializer = ActorMaterializer()
+    val builder = new DefaultAsyncHttpClientConfig.Builder()
+    val client = new AhcWSClient(builder.build())
     new Consul(address, port, token, client)
   }
 }

--- a/src/main/scala/consul/v1/common/ConsulRequestBasics.scala
+++ b/src/main/scala/consul/v1/common/ConsulRequestBasics.scala
@@ -1,10 +1,8 @@
 package consul.v1.common
 
-import com.ning.http.client.AsyncHttpClientConfig
 import consul.v1.common.Types.DatacenterId
 import play.api.libs.json._
 import play.api.libs.ws.{WS, WSClient, WSRequest, WSResponse}
-import play.api.libs.ws.ning.NingWSClient
 import play.api.Application
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}


### PR DESCRIPTION
This upgrades the Play libraries used to 2.5, making it possible to use scala-consul within projects using the new Play version, as otherwise there are clashes between the different library versions and dependencies in use.
